### PR TITLE
Update balena.yml to use a 3 digit semver

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.0.0"
 slug: "ledfx-balena-sound"
 name: "LedFx-balenaSound"
 type: "sw.application"


### PR DESCRIPTION
This will become the new suggested version format in an upcoming balenaCloud release.
The old format will still be supported but will become deprecated.
By adopting this 3 digit semver format, builds with the same version will no longer fails with a unique constraint error, since the balenaCloud backend will auto-increment its revision to avoid such clashes.